### PR TITLE
Day1 data pipeline

### DIFF
--- a/scripts/build_faiss_samples.py
+++ b/scripts/build_faiss_samples.py
@@ -1,3 +1,5 @@
+
+from pathlib import Path
 import os, numpy as np, faiss
 import pathlib
 import os, json, numpy as np, faiss

--- a/scripts/hf_embed_min.py
+++ b/scripts/hf_embed_min.py
@@ -1,4 +1,5 @@
 # Minimal: load CLIP, embed up to 20 images from a parquet file, save embeddings.npy
+from hf_embed_global import embed_images
 import argparse, os, json
 from pathlib import Path
 import numpy as np, pandas as pd
@@ -6,19 +7,20 @@ from PIL import Image
 import torch
 from transformers import CLIPModel, CLIPProcessor
 
-from scripts.clip_core import embed_images  # <<< new import
+#from clip_core import embed_images  # <<< new import
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--parquet", default="data/corpus/samples20.parquet")
     parser.add_argument("--out-dir", default="data/embeddings_samples")
+    parser.add_argument("--limit", type=int, default=20, help="Max number of images to embed")
     args = parser.parse_args()
 
     # 1) load file list
     # read mega data of those file images
     df = pd.read_parquet(args.parquet)
     paths = [p for p in df["local_path"].tolist() if isinstance(p, str) and os.path.exists(p)]
-    paths = paths[:20]  # cap at 20
+    paths = paths[: args.limit]
 
     # 3) load images and preprocess (one small batch)
     images = [Image.open(p).convert("RGB") for p in paths]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a retrying MET API session with metadata-only and year filters plus parquet normalization; switches FAISS paths to repo-root; and adds a configurable image limit to the embedding script.
> 
> - **Data collection (`scripts/download_met_images.py`)**:
>   - HTTP session with retries and custom headers; replace direct `requests.get` with `SESSION.get`.
>   - New CLI flags: `--metadata-only`, `--min-year`, `--max-year`, `--balance-by-century`, `--per-century`.
>   - Year parsing (`extract_year`) and filtering; compute century bin; safer object fetch with try/except.
>   - Conditional `local_path` handling and updated download logic; supports URL-only rows.
>   - Normalize dtypes and column ordering before writing parquet; merge with dedupe retained.
> - **Indexing (`scripts/build_faiss_samples.py`)**:
>   - Resolve `EMB`, `META_IN`, and `OUT` relative to repo root; ensure output directory exists.
> - **Embedding (`scripts/hf_embed_min.py`)**:
>   - Use `embed_images` from `hf_embed_global`; add `--limit` to cap processed images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 435af626bec1f4f2b6952339fafc0f2e0f45f512. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->